### PR TITLE
Fixes for timestamped message

### DIFF
--- a/main.py
+++ b/main.py
@@ -125,7 +125,8 @@ def new_process(data: dict) -> dict:
         if item['type'] in [LogicType.group, LogicType.union]:
             # Replace (double) reference for group and union elements by element, so we can work with the name and type.
             item['value']['elements'] = {name: logic_types[logic_types[el['value']]['value']]
-                                         for name, el in item['value']['elements'].items()}
+                                         for name, el in item['value']['elements'].items()
+                                         if logic_types[el['value']]['type'] == LogicType.ref}
 
         if item['type'] == LogicType.stream:
             # Replace reference for stream elements, so we can work with the name and type.

--- a/main.py
+++ b/main.py
@@ -109,6 +109,12 @@ def new_process(data: dict) -> dict:
                 l = l + find_child_streams(el, new_path)
         return l
 
+    def solve_ref(data: dict, name: str) -> dict:
+        solve = data[name]
+        if solve['type'] == LogicType.ref:
+            return solve_ref(data, solve['value'])
+        return solve
+
     for (key, item) in logic_types.items():
         item['type'] = LogicType(item['type'])
         set_name(item)
@@ -124,9 +130,8 @@ def new_process(data: dict) -> dict:
 
         if item['type'] in [LogicType.group, LogicType.union]:
             # Replace (double) reference for group and union elements by element, so we can work with the name and type.
-            item['value']['elements'] = {name: logic_types[logic_types[el['value']]['value']]
-                                         for name, el in item['value']['elements'].items()
-                                         if logic_types[el['value']]['type'] == LogicType.ref}
+            item['value']['elements'] = {name: solve_ref(logic_types, el['value'])
+                                         for name, el in item['value']['elements'].items()}
 
         if item['type'] == LogicType.stream:
             # Replace reference for stream elements, so we can work with the name and type.

--- a/templates/elements.scala
+++ b/templates/elements.scala
@@ -44,12 +44,12 @@ class {{type.name | capitalize}} extends Union({{ type.value.elements.keys() | l
 {% macro stream(name, type, types) -%}
 {{ documentation_short(type, "Stream") }}
 class {{ name | capitalize }} extends PhysicalStreamDetailed(e=new {{type.value.stream_type.name | capitalize}}, n={{type.value.throughput | int}}, d={{type.value.dimension}}, c={{type.value.complexity}}, r={{'true' if type.value.direction=='Reverse' else 'false'}}, u={% if type.value.user_type.type == LogicType.null %}Null(){% else %}new {{type.value.user_type.name | capitalize}}{% endif %})
-{%- endmacro %}
-
-{% macro stream_ref(type, types) -%}
-{{ stream(type.name, types[type.value], types) }}
 
 object {{ type.name | capitalize }} {
     def apply(): {{ type.name | capitalize }} = Wire(new {{ type.name | capitalize }}())
 }
+{%- endmacro %}
+
+{% macro stream_ref(type, types) -%}
+{{ stream(type.name, types[type.value], types) }}
 {%- endmacro %}

--- a/templates/elements.scala
+++ b/templates/elements.scala
@@ -11,7 +11,7 @@
 {%- endmacro %}
 
 {% macro bit(type) -%}
-{{ documentation_short(type, "Bit(" + type.value  + ")") }}
+{{ documentation_short(type, "Bit(" + type.value | string + ")") }}
 class {{type.name | capitalize}} extends BitsEl({{type.value}}.W)
 {%- endmacro %}
 

--- a/templates/output.scala
+++ b/templates/output.scala
@@ -46,7 +46,11 @@ class {{ streamlet.name | capitalize }} extends TydiModule {
 {%- for impl in implementations.values() %}
 {{ els.documentation(impl, "Implementation") }}
 class {{ impl.name | capitalize }} extends {{ impl.derived_streamlet.name | capitalize }} {
-{%- if impl.implementation_instances %}
+{%- for port in impl.derived_streamlet.ports.values() %}
+    // Fixme: Remove the following line if this impl. contains logic. If it just interconnects, remove this comment.
+    {{ port.name }}Stream := DontCare
+{%- endfor %}
+{% if impl.implementation_instances %}
     // Modules
   {%- for inst in impl.implementation_instances.values() %}
     {% if inst.document %}/** {{ inst.document | sentence }} */

--- a/templates/output.scala
+++ b/templates/output.scala
@@ -15,14 +15,14 @@ object MyTypes {
 }
 
 {% for type in logic_types.values() if type.unique -%}
-{% if type.type == LogicType.group %}
+{% if type.type == LogicType.bit %}
+{{ els.bit(type) }}
+{% elif type.type == LogicType.group %}
 {{ els.group(type, logic_types) }}
 {% elif type.type == LogicType.union %}
 {{ els.union(type, logic_types) }}
 {% elif type.type == LogicType.stream %}
 {{ els.stream(type.name, type, logic_types) }}
-{% elif type.type == LogicType.ref and logic_types[type.value].type == LogicType.stream %}
-{{ els.stream_ref(type, logic_types) }}
 {% endif -%}
 {% endfor %}
 

--- a/templates/output.scala
+++ b/templates/output.scala
@@ -29,16 +29,17 @@ object MyTypes {
 {%- for streamlet in streamlets.values() %}
 {{ els.documentation(streamlet, "Streamlet") }}
 class {{ streamlet.name | capitalize }} extends TydiModule {
-  {%- for port in streamlet.ports.values() %}
+{%- for port in streamlet.ports.values() %}
     /** Stream of [[{{ port.name }}]] with {{ port.direction.name }} direction.{% if port.document %} {{ port.document | sentence }}{% endif %} */
     val {{ port.name }}Stream = {{ port.logic_type.name | capitalize }}(){% if port.direction == Direction.input %}.flip{% endif %}
     /** IO of [[{{ port.name }}Stream]] with {{ port.direction.name }} direction. */
     val {{ port.name }} = {{ port.name }}Stream.toPhysical
 
     {%- for sub_port in port.sub_streams %}
-        val {{ sub_port.name }} = {{ port.name }}Stream.{{ '.'.join(sub_port.path) }}.toPhysical
+        /** IO of "{{sub_port.name}}" sub-stream of [[{{ port.name }}Stream]] with {{ port.direction.name }} direction. */
+        val {{ port.name }}_{{ sub_port.name }} = {{ port.name }}Stream.{{ '.'.join(sub_port.path) }}.toPhysical
     {%- endfor %}
-  {%- endfor %}
+{% endfor -%}
 }
 {% endfor %}
 
@@ -60,7 +61,7 @@ class {{ impl.name | capitalize }} extends {{ impl.derived_streamlet.name | capi
     {% endif -%}
     {% if con.sink_port_owner_name != "self" %}{{ con.sink_owner.name }}.{% endif %}{{ con.sink_port_name }} := {% if con.src_port_owner_name != "self" %}{{ con.src_owner.name }}.{% endif %}{{ con.src_port_name }}
     {%- for sub_con in con.sub_streams %}
-        {% if con.sink_port_owner_name != "self" %}{{ con.sink_owner.name }}.{% endif %}{{ sub_con.name }} := {% if con.src_port_owner_name != "self" %}{{ con.src_owner.name }}.{% endif %}{{ sub_con.name }}
+        {% if con.sink_port_owner_name != "self" %}{{ con.sink_owner.name }}.{% endif %}{{ con.sink_port_name }}_{{ sub_con.name }} := {% if con.src_port_owner_name != "self" %}{{ con.src_owner.name }}.{% endif %}{{ con.src_port_name }}_{{ sub_con.name }}
     {%- endfor %}
   {%- endfor %}
 {% endif -%}


### PR DESCRIPTION
This is a PR that fixes several issues that came up while trying to develop the "timestamped message" example from the Tydi-spec paper.

- Variable names for nested streams have been fixed.
- Emit correct streams, with companion objects, without duplicates.
- Place optional connections of detailed streams to `DontCare`. For when a component is interconnecting only and does not use the detailed streams.
- Generate `Bit` element classes in addition to usage in `MyTypes` for streams directly using low level (bit) types.
- Fix an issue for references of `Group`/`Union` elements.