### PR TITLE
Add support for @External modules and duplicator components.

### DIFF
--- a/templates/chisel_components.scala
+++ b/templates/chisel_components.scala
@@ -1,0 +1,46 @@
+{% import 'elements.scala' as els -%}
+/*
+ * This file contains all modules of the "{{ compile_options.package_of_top_level_implementation }}" package which are not external.
+ * The `streamlet` interface definitions can be found in the `..._main.scala` file. You can use the implementation
+ * definitions in this file as a basis for your own Chisel components. If you want to develop them separately, mark them
+ * as @External in your Tydi-lang code.
+ */
+
+import nl.tudelft.tydi_chisel._
+import chisel3._
+import {{ compile_options.package_of_top_level_implementation }}._
+
+{% macro internal_impl(impl) -%}
+{{ els.documentation(impl, "Implementation") }}
+class {{ impl.name | capitalize }} extends {{ impl.derived_streamlet.name | capitalize }} {
+{%- for port in impl.derived_streamlet.ports.values() %}
+    // Fixme: Remove the following line if this impl. contains logic. If it just interconnects, remove this comment.
+    {{ port.name }}Stream := DontCare
+{%- endfor %}
+{% if impl.implementation_instances %}
+    // Modules
+  {%- for inst in impl.implementation_instances.values() %}
+    {% if inst.document %}/** {{ inst.document | sentence }} */
+    {% endif -%}
+    val {{ inst.name }} = Module(new {{ inst.impl.name | capitalize }})
+  {%- endfor %}
+{% endif %}
+{%- if impl.nets %}
+    // Connections
+  {%- for con in impl.nets.values() %}
+    {% if con.document %}// {{ con.document | sentence }}
+    {% endif -%}
+    {% if con.sink_port_owner_name != "self" %}{{ con.sink_owner.name }}.{% endif %}{{ con.sink_port_name }} := {% if con.src_port_owner_name != "self" %}{{ con.src_owner.name }}.{% endif %}{{ con.src_port_name }}
+    {%- for sub_con in con.sub_streams %}
+        {% if con.sink_port_owner_name != "self" %}{{ con.sink_owner.name }}.{% endif %}{{ con.sink_port_name }}_{{ sub_con.name }} := {% if con.src_port_owner_name != "self" %}{{ con.src_owner.name }}.{% endif %}{{ con.src_port_name }}_{{ sub_con.name }}
+    {%- endfor %}
+  {%- endfor %}
+{% endif -%}
+}
+{%- endmacro %}
+
+{%- for impl in implementations.values() %}
+{%- if not "External" in impl.attributes -%}
+    {{ internal_impl(impl) }}
+{%- endif %}
+{%- endfor %}

--- a/templates/chisel_components.scala
+++ b/templates/chisel_components.scala
@@ -22,7 +22,7 @@ class {{ impl.name | capitalize }} extends {{ impl.derived_streamlet.name | capi
   {%- for inst in impl.implementation_instances.values() %}
     {% if inst.document %}/** {{ inst.document | sentence }} */
     {% endif -%}
-    val {{ inst.name }} = Module(new {{ inst.impl.name | capitalize }})
+    private val {{ inst.name }} = Module(new {{ inst.impl.name | capitalize }})
   {%- endfor %}
 {% endif %}
 {%- if impl.nets %}

--- a/templates/elements.scala
+++ b/templates/elements.scala
@@ -41,6 +41,10 @@ class {{type.name | capitalize}} extends Union({{ type.value.elements.keys() | l
 }
 {%- endmacro %}
 
+{% macro io_stream(name, type, types) -%}
+PhysicalStream(e=new {{type.value.stream_type.name | capitalize}}, n={{type.value.throughput | int}}, d={{type.value.dimension}}, c={{type.value.complexity}}, u={% if type.value.user_type.type == LogicType.null %}Null(){% else %}new {{type.value.user_type.name | capitalize}}{% endif %})
+{%- endmacro %}
+
 {% macro stream(name, type, types) -%}
 {{ documentation_short(type, "Stream") }}
 class {{ name | capitalize }} extends PhysicalStreamDetailed(e=new {{type.value.stream_type.name | capitalize}}, n={{type.value.throughput | int}}, d={{type.value.dimension}}, c={{type.value.complexity}}, r={{'true' if type.value.direction=='Reverse' else 'false'}}, u={% if type.value.user_type.type == LogicType.null %}Null(){% else %}new {{type.value.user_type.name | capitalize}}{% endif %})

--- a/templates/generation_stub.scala
+++ b/templates/generation_stub.scala
@@ -1,0 +1,18 @@
+package org.example.{{ compile_options.package_of_top_level_implementation }}
+
+import {{ compile_options.package_of_top_level_implementation }}.{{ compile_options.top_level_implementation | capitalize }}
+
+import chisel3._
+import circt.stage.ChiselStage
+
+import java.io.{File, FileWriter}
+
+object {{ compile_options.package_of_top_level_implementation | snake2pascal }} extends App {
+  // Generate the Verilog output
+  private val {{ compile_options.top_level_implementation | snake2camel }}Verilog: String = ChiselStage.emitSystemVerilog(new {{ compile_options.top_level_implementation | capitalize }})
+
+  println({{ compile_options.top_level_implementation | snake2camel }}Verilog)
+  private val writer = new FileWriter(new File("{{ output_dir }}/{{ compile_options.package_of_top_level_implementation }}.v"))
+  writer.write({{ compile_options.top_level_implementation | snake2camel }}Verilog)
+  writer.close()
+}

--- a/templates/output.scala
+++ b/templates/output.scala
@@ -1,5 +1,5 @@
 {% import 'elements.scala' as els -%}
-package some_tydi_project
+package {{ compile_options.package_of_top_level_implementation }}
 
 import nl.tudelft.tydi_chisel._
 import chisel3._
@@ -112,7 +112,8 @@ class {{ impl.name | capitalize }} extends {{ impl.derived_streamlet.name | capi
     {{ duplicator(impl) }}
 {% elif "External" in impl.attributes -%}
     {{ external_impl(impl) }}
-{%- else -%}
+{%- elif impl.implementation_instances -%}
+    {#- This means an internal implementation that is not empty! -#}
     {{ internal_impl(impl) }}
 {%- endif %}
 {% endfor %}

--- a/templates/output.scala
+++ b/templates/output.scala
@@ -84,7 +84,7 @@ class {{ impl.name | capitalize }} extends TydiExtModule {
 
     {%- for sub_port in port.sub_streams %}
         /** IO of "{{sub_port.name}}" sub-stream of [[{{ port.name }}Stream]] with {{ port.direction.name }} direction. */
-        val {{ port.name }}{{ '_'.join(sub_port.path) }} = IO({% if port.direction == Direction.input %}Flipped({% endif %}new {{ els.io_stream(sub_port.logic_type.name, sub_port.logic_type, logic_types) }}{% if port.direction == Direction.input %}}({% endif %})
+        val {{ port.name }}_{{ sub_port.name }} = IO({% if port.direction == Direction.input %}Flipped({% endif %}new {{ els.io_stream(sub_port.name, sub_port.logic_type, logic_types) }}{% if port.direction == Direction.input %}){% endif %})
     {%- endfor %}
 {% endfor -%}
 }

--- a/templates/output.scala
+++ b/templates/output.scala
@@ -110,7 +110,7 @@ class {{ impl.name | capitalize }} extends {{ impl.derived_streamlet.name | capi
 {%- for impl in implementations.values() %}
 {% if impl.type == ImplType.duplicator -%}
     {{ duplicator(impl) }}
-{% elif "External" in impl.attributes -%}
+{% elif "External" in impl.attributes or (external_only and impl.implementation_instances|length == 0) -%}
     {{ external_impl(impl) }}
 {%- elif impl.implementation_instances -%}
     {#- This means an internal implementation that is not empty! -#}

--- a/tydi-lang-2-chisel.py
+++ b/tydi-lang-2-chisel.py
@@ -31,6 +31,13 @@ class Direction(Enum):
     output = 'Out'
 
 
+class ImplType(Enum):
+    normal = 'normal'
+    template_instance = 'TemplateInstance'
+    duplicator = 'duplicator'
+    voider = 'voider'
+
+
 def pre_process(data: dict, solve: str, l: list[dict]) -> list[dict]:
     item = data.get(solve)
     item_type = LogicType(item['type'])
@@ -167,6 +174,13 @@ def new_process(data: dict) -> dict:
             instance['name'] = name.split("__")[1]
             instance["impl"] = implementations[instance['derived_implementation']]
 
+        item['type'] = ImplType.normal if item['impl_type'] == "Normal" else ImplType.template_instance
+        if (item['type'] == ImplType.template_instance):
+            if item['impl_type']['TemplateInstance']['template_name'] == "duplicator_i":
+                item['type'] = ImplType.duplicator
+            elif item['impl_type']['TemplateInstance']['template_name'] == "voider_i":
+                item['type'] = ImplType.voider
+
     # Second, process the port connections. All references must be replaced by the above first or the process may fail.
     for (key, item) in implementations.items():
         # Name ports and substitute references
@@ -230,6 +244,7 @@ def main():
     output_dir = Path(args.output_dir)
 
     env.globals['LogicType'] = LogicType
+    env.globals['ImplType'] = ImplType
     env.globals['Direction'] = Direction
     env.filters['sentence'] = sentence_filter
     env.filters['capitalize'] = new_capitalize

--- a/tydi-lang-2-chisel.py
+++ b/tydi-lang-2-chisel.py
@@ -113,6 +113,7 @@ def new_process(data: dict) -> dict:
                 if el['type'] == LogicType.stream:
                     connection = {
                         'name': name,
+                        'logic_type': stream,
                         'path': new_path
                     }
                     l.append(connection)

--- a/tydi-lang-2-chisel.py
+++ b/tydi-lang-2-chisel.py
@@ -208,9 +208,17 @@ def new_capitalize(value: str):
     return value[:1].upper() + value[1:]
 
 
-def snake2camel(value: str):
+def new_lower(value: str):
+    return value[:1].lower() + value[1:]
+
+
+def snake2pascal(value: str):
     temp = value.split('_')
     return ''.join(el.title() for el in temp)
+
+
+def snake2camel(value: str):
+    return new_lower(snake2pascal(value))
 
 
 def sentence_filter(value: str):
@@ -248,17 +256,23 @@ def main():
     env.globals['Direction'] = Direction
     env.filters['sentence'] = sentence_filter
     env.filters['capitalize'] = new_capitalize
+    env.filters['snake2pascal'] = snake2pascal
     env.filters['snake2camel'] = snake2camel
-    template = env.get_template('output.scala')
+
+    output_files = {
+        "main": env.get_template('output.scala'),
+        "chisel_components": env.get_template('chisel_components.scala'),
+        "generation_stub": env.get_template('generation_stub.scala'),
+    }
 
     for input_file, tydi_data in data.items():
         to_template = new_process(dict(tydi_data))
-        output = template.render(to_template)
-        # print(output)
-        output_file = output_dir.joinpath(f"{input_file.stem}.scala")
-        print(f"Saving output based on {input_file} to {output_file}")
-        with open(output_file, 'w') as f:
-            f.write(output)
+        for name, template in output_files.items():
+            output = template.render(to_template, output_dir=output_dir)
+            output_file = output_dir.joinpath(f"{input_file.stem}_{name}.scala")
+            print(f"Saving output based on {input_file} to {output_file}")
+            with open(output_file, 'w') as f:
+                f.write(output)
 
 
 if __name__ == '__main__':

--- a/tydi-lang-2-chisel.py
+++ b/tydi-lang-2-chisel.py
@@ -230,6 +230,7 @@ def main():
     parser = argparse.ArgumentParser(description="Tydi-Lang-2-Chisel")
     parser.add_argument("output_dir", type=str, help="Output directory")
     parser.add_argument("input", type=str, nargs="*", help="Input file(s) or directory")
+    parser.add_argument("-e", "--external-only", action='store_true', help="If enabled, emit all implementations as external")
     args = parser.parse_args()
 
     data = {}
@@ -269,7 +270,7 @@ def main():
     for input_file, tydi_data in data.items():
         to_template = new_process(dict(tydi_data))
         for name, template in output_files.items():
-            output = template.render(to_template, output_dir=output_dir)
+            output = template.render(to_template, output_dir=output_dir, external_only=args.external_only)
             output_file = output_dir.joinpath(f"{input_file.stem}_{name}.scala")
             print(f"Saving output based on {input_file} to {output_file}")
             with open(output_file, 'w') as f:


### PR DESCRIPTION
Based on the recent additions to Tydi-lang 2 (E.g. https://github.com/twoentartian/tydi-lang-2/commit/72c9128525d25062438fed32b9e056f92e7c0745, https://github.com/twoentartian/tydi-lang-2/commit/3533a253a1ff7253cee65285b7fad1c8bc6d2ccd, https://github.com/twoentartian/tydi-lang-2/commit/0ec6e2b379eb8c29f163463f2681cd75e812a38a), add support for declaring "external modules" by providing the `@External` attribute for an `impl` and the duplicator standard component.

Additionally, improve file generation by

- Emitting the correct package name
- Emitting all modules that are not external to a separate file to easily copy from
- Generating a file with code to compile the generated top level component to Verilog
- Add type information to generated code

Finally, a CLI option is provided to emit all components that do _not_ contain nested instances as external. This is useful to investigate the amount of just interconnection code is saved without the Verilog generation optimizing signals away.