### PR TITLE
Fix deduplication

### DIFF
--- a/tl2chisel/tl2chisel.py
+++ b/tl2chisel/tl2chisel.py
@@ -89,6 +89,7 @@ def new_process(data: dict, auto_naming=True) -> dict:
     implementations = data.get('implementations', {})
 
     def set_name(tag: str, item: dict):
+        item['name'] = tag
         name_parts = tag.split('__')
         scope = name_parts[0]
         item['scope_type'], item['scope_name'] = scope.split("_", 1)
@@ -98,8 +99,7 @@ def new_process(data: dict, auto_naming=True) -> dict:
             item['defined'] = False
         if len(name_parts) == 1:
             item['unique'] = False
-            item['name'] = tag
-        else:
+        elif item['defined']:
             item['name'] = name_parts[1].lstrip('_')
 
     def filter_port_name(name: str) -> str:
@@ -172,8 +172,8 @@ def new_process(data: dict, auto_naming=True) -> dict:
         item['type'] = LogicType(item['type'])
         set_name(key, item)
 
+        # Remove all duplicate logic types from emission
         check_name = f"{item['name']}.{item['type']}"
-        # Do not add items that do not have a scope to the doubles check (set as non-unique in name setting)
         deduplicate(check_name, item)
 
         if item['type'] in [LogicType.group, LogicType.union]:

--- a/tl2chisel/tl2chisel.py
+++ b/tl2chisel/tl2chisel.py
@@ -59,13 +59,15 @@ def stream_namer(stream: dict) -> str:
         "throughput": 1.0,
         "synchronicity": "Sync",
         "complexity": 1,
+        "dimensionality": 1,
         "direction": "Forward",
     }
     short_names = {
         "throughput": "t",
         "synchronicity": "s",
         "complexity": "c",
-        "direction": "d"
+        "dimensionality": "d",
+        "direction": "r"
     }
     data_type_name = properties['stream_type']['name']
     user_type_name = properties['user_type']['name'] if properties['user_type']['type'] != LogicType.null else None

--- a/tl2chisel/tl2chisel.py
+++ b/tl2chisel/tl2chisel.py
@@ -159,7 +159,7 @@ def new_process(data: dict, auto_naming=True) -> dict:
         if item.get('unique', True) and not doubles_check.get(name, False):
             doubles_check[name] = item
             item['unique'] = True
-        else:
+        elif doubles_check.get(name, False) != item:
             item['unique'] = False
             if doubles_check.get(name, False) and item['type'] == LogicType.stream:
                 item['value']['stream_type'] = doubles_check[name]['value']['stream_type']
@@ -240,6 +240,7 @@ def new_process(data: dict, auto_naming=True) -> dict:
     for (key, item) in logic_types.items():
         aliases = item.get("alias", [])
         if len(aliases) > 0:
+            item['original_name'] = item['name']
             item['name'] = aliases[-1]
             if item['scope_type'] == "instance":
                 item['name'] = f"{item['name']}_{item['scope_name']}"
@@ -252,8 +253,9 @@ def new_process(data: dict, auto_naming=True) -> dict:
             if item['type'] == LogicType.stream:
                 auto_name = stream_namer(item)
                 if item['name'].startswith("generated"):
+                    item['original_name'] = item['name']
                     item['name'] = auto_name
-                deduplicate(auto_name, item)
+                deduplicate(item['name'], item)
 
     return data
 


### PR DESCRIPTION
This PR fixes some important issues with the deduplication that were causing incorrect output.

- Remove the possibility of items being marked as duplicates of themselves by passing through deduplication multiple times.
- Add the dimensionality to the auto stream namer properties. I don't know how I managed to miss that one...
- Duplicator streams had the same signal name but different scope names. The scope was removed from the name, resulting in incorrect deduplication of different streams. Streams with anonymous scopes now do not get their scope removed.
  - This happened before the stream auto-namer got a chance to discern them, but the renamer is optional, so it should also work without it.